### PR TITLE
Implement history-to-outgoing.js CLI tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-1-e92b6d33
+Your prepared working directory: /tmp/gh-issue-solver-1760722644227
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-1-e92b6d33
-Your prepared working directory: /tmp/gh-issue-solver-1760722644227
-
-Proceed.

--- a/experiments/sample-history-outgoing.json
+++ b/experiments/sample-history-outgoing.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "2",
+    "author": "Me",
+    "date": "2023-12-15T10:31:00.000Z",
+    "isEdited": false,
+    "text": "I'm doing great, thanks!"
+  },
+  {
+    "id": "4",
+    "author": "Me",
+    "date": "2023-12-15T10:33:00.000Z",
+    "isEdited": true,
+    "text": "What about you?"
+  }
+]

--- a/experiments/sample-history.json
+++ b/experiments/sample-history.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "1",
+    "author": "John Doe",
+    "date": "2023-12-15T10:30:00.000Z",
+    "isEdited": false,
+    "text": "Hello, how are you?"
+  },
+  {
+    "id": "2",
+    "author": "Me",
+    "date": "2023-12-15T10:31:00.000Z",
+    "isEdited": false,
+    "text": "I'm doing great, thanks!"
+  },
+  {
+    "id": "3",
+    "author": "John Doe",
+    "date": "2023-12-15T10:32:00.000Z",
+    "isEdited": false,
+    "text": "That's wonderful!"
+  },
+  {
+    "id": "4",
+    "author": "Me",
+    "date": "2023-12-15T10:33:00.000Z",
+    "isEdited": true,
+    "text": "What about you?"
+  }
+]

--- a/history-to-outgoing.js
+++ b/history-to-outgoing.js
@@ -1,1 +1,40 @@
+console.time('Execution Time');
 
+const fs = require('fs');
+const path = require('path');
+const { program } = require('commander');
+
+program
+  .requiredOption('-s, --source <path>', 'source JSON file with message history')
+  .option('-t, --target <path>', 'target JSON file for outgoing messages')
+  .requiredOption('-a, --author <name>', 'author name to filter (your name in the chat)');
+
+program.parse(process.argv);
+
+const options = program.opts();
+if (!options.source) {
+  console.log('--source is required');
+  process.exit(1);
+}
+if (!options.author) {
+  console.log('--author is required');
+  process.exit(1);
+}
+
+let sourcePath = options.source;
+let targetPath = options.target || path.join(path.dirname(sourcePath), `${path.basename(sourcePath, '.json')}-outgoing.json`);
+let authorName = options.author;
+
+// Read the source JSON file
+const sourceData = fs.readFileSync(sourcePath, 'utf-8');
+const messages = JSON.parse(sourceData);
+
+// Filter outgoing messages (messages authored by the specified author)
+const outgoingMessages = messages.filter(message => message.author === authorName);
+
+// Write the filtered messages to the target file
+fs.writeFileSync(targetPath, JSON.stringify(outgoingMessages, null, 2));
+
+console.log(`Filtered ${outgoingMessages.length} outgoing messages from ${messages.length} total messages`);
+console.log(`Outgoing messages saved to ${targetPath}`);
+console.timeEnd('Execution Time');


### PR DESCRIPTION
## Summary

This PR implements the `history-to-outgoing.js` CLI tool that filters message history JSON files to extract only outgoing messages (messages sent by a specified author).

## Implementation Details

The script:
- Accepts a source JSON file path (`-s, --source`)
- Accepts an optional target JSON file path (`-t, --target`)
- Requires an author name parameter (`-a, --author`) to identify which messages are outgoing
- Filters the message history to include only messages from the specified author
- Outputs the filtered messages to a JSON file
- Reports execution time and message counts

## Usage

```bash
node history-to-outgoing.js -s path/to/history.json -a "Your Name" [-t path/to/output.json]
```

## Example

The `experiments/` folder contains sample input and output files demonstrating the tool's functionality:
- `sample-history.json` - Example input with messages from multiple authors
- `sample-history-outgoing.json` - Example output with only messages from "Me"

## Test Plan

- [x] Script successfully filters messages by author
- [x] Default output path is generated correctly when not specified
- [x] Execution time is measured and reported
- [x] Message counts are displayed to the user

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)